### PR TITLE
Fixed restoring properties of floating nodes from file

### DIFF
--- a/src/main/java/org/dockfx/DockPane.java
+++ b/src/main/java/org/dockfx/DockPane.java
@@ -925,8 +925,8 @@ public class DockPane extends StackPane implements EventHandler<DockEvent> {
 				node.getStage().setX(position[0]);
 				node.getStage().setY(position[1]);
 
-				node.getStage().setWidth(size[0]);
-				node.getStage().setHeight(size[1]);
+				node.setFloatingWidth(size[0]);
+				node.setFloatingHeight(size[1]);
 
 				node.setFloating(true);
 				node.closedProperty().setValue(false);


### PR DESCRIPTION
setting floating width/height properties of node in order to properly set floating mode afterwards when loading saved properties from file